### PR TITLE
Enable Poetry as an optional build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyreadline"
-version = "2.2.0"
+version = "2.2.1"
 description = "A python implementation of GNU readline functionality, based on the ctypes-based UNC readline package by Gary Bishop"
 homepage = "https://ipython.org/pyreadline"
 repository = "https://github.com/djstompzone/pyreadline"
@@ -21,19 +21,6 @@ classifiers = [
     "Development Status :: 6 - Mature",
     "Environment :: Console",
     "Operating System :: Microsoft :: Windows",
-    "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Terminals",
@@ -42,6 +29,10 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=2.7,<4.0"
+pywin32 = "^308"
+
+[tool.poetry.dev-dependencies]
+sphinx = "^5.0" 
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[tool.poetry]
+name = "pyreadline"
+version = "2.2.0"
+description = "A python implementation of GNU readline functionality, based on the ctypes-based UNC readline package by Gary Bishop"
+homepage = "https://ipython.org/pyreadline"
+repository = "https://github.com/djstompzone/pyreadline"
+authors = [
+    "Jörgen Stenarson <jorgen.stenarson@bostream.nu>",
+    "Gary Bishop <gb@cs.unc.edu>",
+    "Jack Trainor <unknown@unknown.com>",
+    "Takayuki Shimizukawa <shimizukawa@gmail.com>",
+    "DJ Magar <admin@stomp.zone>",
+]
+maintainers = [
+     "DJ Magar <admin@stomp.zone>",
+     "Jörgen Stenarson <jorgen.stenarson@bostream.nu>"
+]
+license = "BSD-3-Clause"
+readme = ["README.rst", "doc/README.txt"]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Environment :: Console",
+    "Operating System :: Microsoft :: Windows",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Terminals",
+    "Topic :: Utilities"
+]
+
+[tool.poetry.dependencies]
+python = ">=2.7,<4.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Introduced `pyproject.toml` in order to add support for [Poetry](https://python-poetry.org/) as an optional build system. 

This update adheres to [PEP 517](https://peps.python.org/pep-0517/) and provides developers with an opt-in alternative for managing dependencies and builds, without breaking backwards compatibility with legacy `distutils` installs. 

**Key Changes:**
- Added `pyproject.toml` to support builds via Poetry.
- Does not subsume legacy `distutils` support or affect installation methods on older (< 3.7) versions of python.
- This allows for flexibility in the choice of build system and functions as a much needed QoL update moving forward.